### PR TITLE
Issue 7

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,7 +395,6 @@ impl IdentifierLike for AccountIdentifier {
                 && s.chars()
                     .all(|c| c.is_ascii_digit() || c == CHAR_WILD_ONE || c == CHAR_WILD_ANY)
                 && s.chars().any(|c| c == CHAR_WILD_ONE || c == CHAR_WILD_ANY))
-            || s == "aws"
     }
 }
 
@@ -608,7 +607,7 @@ impl FromStr for ResourceName {
                 } else {
                     Some(Identifier::from_str(parts[3])?)
                 },
-                account_id: if parts[4].is_empty() {
+                account_id: if parts[4].is_empty() || parts[4] == "aws" {
                     None
                 } else {
                     Some(AccountIdentifier::from_str(parts[4])?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,7 @@ impl IdentifierLike for AccountIdentifier {
                 && s.chars()
                     .all(|c| c.is_ascii_digit() || c == CHAR_WILD_ONE || c == CHAR_WILD_ANY)
                 && s.chars().any(|c| c == CHAR_WILD_ONE || c == CHAR_WILD_ANY))
+            || s == "aws"
     }
 }
 
@@ -607,7 +608,7 @@ impl FromStr for ResourceName {
                 } else {
                     Some(Identifier::from_str(parts[3])?)
                 },
-                account_id: if parts[4].is_empty() || parts[4] == "aws" {
+                account_id: if parts[4].is_empty() {
                     None
                 } else {
                     Some(AccountIdentifier::from_str(parts[4])?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,7 @@ impl IdentifierLike for AccountIdentifier {
                 && s.chars()
                     .all(|c| c.is_ascii_digit() || c == CHAR_WILD_ONE || c == CHAR_WILD_ANY)
                 && s.chars().any(|c| c == CHAR_WILD_ONE || c == CHAR_WILD_ANY))
+            || s == "aws"
     }
 }
 
@@ -554,7 +555,7 @@ impl Display for ResourceName {
         write!(
             f,
             "{}",
-            vec![
+            [
                 ARN_PREFIX.to_string(),
                 self.partition
                     .as_ref()

--- a/tests/test_arn.rs
+++ b/tests/test_arn.rs
@@ -78,3 +78,10 @@ fn test_github_issues_2() {
     );
     assert!(arn.resource.contains_qualified());
 }
+
+/// Check that an AWS managed IAM policy ARN is correctly parsed
+#[test]
+fn test_github_issues_7() {
+    let result = ResourceName::from_str("arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess");
+    assert!(result.is_ok());
+}

--- a/tests/test_arn.rs
+++ b/tests/test_arn.rs
@@ -82,6 +82,8 @@ fn test_github_issues_2() {
 /// Check that an AWS managed IAM policy ARN is correctly parsed
 #[test]
 fn test_github_issues_7() {
-    let result = ResourceName::from_str("arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess");
+    let s = "arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess";
+    let result = ResourceName::from_str(s);
     assert!(result.is_ok());
+    assert_eq!(result.unwrap().to_string().as_str(), s);
 }

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -6,7 +6,7 @@ const EXAMPLES: &str = include_str!("examples.txt");
 #[test]
 fn test_examples_from_file() {
     for (line, arn_str) in EXAMPLES.lines().enumerate() {
-        if !arn_str.starts_with("#") {
+        if !arn_str.starts_with('#') {
             println!("{:0>4}: {}", line + 1, arn_str);
             let parsed = ResourceName::from_str(arn_str);
             println!("{:#?}", parsed);

--- a/tests/test_resource_identifier.rs
+++ b/tests/test_resource_identifier.rs
@@ -66,7 +66,7 @@ fn test_resource_identifier_is_valid_variable() {
 fn test_resource_identifier_valid_replacement() {
     let id = ResourceIdentifier::new_unchecked("${greeting} ${name}!");
     let replacements: HashMap<String, String> =
-        HashMap::from_iter(vec![("name".to_string(), "Simon".to_string())].into_iter());
+        HashMap::from_iter(vec![("name".to_string(), "Simon".to_string())]);
     let new_id = id.replace_variables(&replacements).unwrap();
     assert_eq!(new_id.deref(), "${greeting} Simon!");
 }
@@ -75,7 +75,7 @@ fn test_resource_identifier_valid_replacement() {
 fn test_resource_identifier_invalid_replacement() {
     let id = ResourceIdentifier::new_unchecked("${greeting} ${name}!");
     let replacements: HashMap<String, String> =
-        HashMap::from_iter(vec![("name".to_string(), "bad\nвал".to_string())].into_iter());
+        HashMap::from_iter(vec![("name".to_string(), "bad\nвал".to_string())]);
     let new_id = id.replace_variables(&replacements);
     assert!(new_id.is_err());
 }


### PR DESCRIPTION
Fix parsing of AWS managed policy ARNs, such as `"arn:aws:iam::aws:policy/ReadOnlyAccess"`.

Fix #7
